### PR TITLE
Typo fixed "Command" in INSTALL.me

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ The FarmData2 repository contains a sample database with anonymized data from se
 ./setDB.bash sample
 ```
 
-When this command completes there should be a `db` directory in the `docker` directory.  The files in this `db` directory are a mySQL database that contain the sample data.  Note that you will only need to do this step once. But the above comman can be used at any time to reset the database to its initial state.
+When this command completes there should be a `db` directory in the `docker` directory.  The files in this `db` directory are a mySQL database that contain the sample data.  Note that you will only need to do this step once. But the above command can be used at any time to reset the database to its initial state.
 
 #### Starting FarmData2 ####
 


### PR DESCRIPTION
__Pull Request Description__

### Current Issue
The word "comman" should be "command" in the sentence "But the above comman can be used ..." that appears at the end of the "Install the Sample Database Image" section of the INSTALL.md document.

### Fixed Issue
The word "comman" fixed to "command" in the sentence "But the above comman can be used ..." in ISTALL.md which Fixes #15 


---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
