### PR TITLE
Add missing 'with' between 'experiment' and 'FarmData2'

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_example/README.md
+++ b/farmdata2_modules/fd2_tabs/fd2_example/README.md
@@ -1,6 +1,6 @@
 # FarmData2 Modules #
 
-FarmData2 is built using Drupal modules that run within FarmOS. The _FieldKit_ and _BarnKit_ tabs in the FarmData2 interface are created by modules. The _FD2 Example_ tab is created by a sample module and can be used as a sandbox in which to learn about and experiment FarmData2 modules like those that produce the _FieldKit_ and _BarnKit_ tabs.
+FarmData2 is built using Drupal modules that run within FarmOS. The _FieldKit_ and _BarnKit_ tabs in the FarmData2 interface are created by modules. The _FD2 Example_ tab is created by a sample module and can be used as a sandbox in which to learn about and experiment with FarmData2 modules like those that produce the _FieldKit_ and _BarnKit_ tabs.
 
 ## FarmData2 Module Structure ##
 


### PR DESCRIPTION
__Pull Request Description__

Adding the word "with" between "experiment" and "FarmData2" in the sentence "The FD2 Example tab is created by a sample module and can be used as a sandbox in which to learn about and experiment FarmData2 modules like those that produce the FieldKit and BarnKit tabs." at the end of the paragraph following the "FarmData2 Modules" heading in the README.md file in the "farmdata2_modules/fd2_tabs/fd2_example" directory.
Fixes #3 
---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
