### PR TITLE
'Set the upstream remote' link added 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ As a reference, the basic steps for working with GitHub Flow are as follows:
   * Go to the [FarmData2 Repository] (the _upstream_)
   * [Fork](https://docs.gihub.com/en/get-started/quickstart/fork-a-repo) the _upstream_ repository to your GitHub (the _origin_).
   * [Clone] the _origin_ repository to your local machine.
-  * Set the  _upstream_ remote for your local repository to point to the _upstream_ repository.
+  * [Set the  _upstream_ remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork) for your local repository to point to the _upstream_ repository.
   * Create a _feature branch_ from the _main_ branch your local machine.
   * Make the edits to the documentation or the code in your _feature branch_.
   * Commit your edits.


### PR DESCRIPTION
__Pull Request Description__

Fixes #16 
File: CONTRIBUTING.md
Section: Wordflow
Change: a hyperlink embedded into 'Set the upstream remote'

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
