### PR TITLE
Make the text DUE-2013069 into a link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Support and assistance with FarmData2 development has been received from [The No
 The development of FarmData2 has received partial support from:
 * The GNOME Community Engagement Challenge:
   * [![Phase 1 Badge](media/GNOME-CEC-p1-small.png)](media/GNOME-CEC-p1.png)[![Phase 2 Badge](media/GNOME-CEC-p2-small.png)](media/GNOME-CEC-p2.png)    
-* The National Science Foundation (DUE-2013069) - Collaborative Research: Broadening Participation in Computing through Authentic, Collaborative Engagement with Computing for the Greater Good.
+* The National Science Foundation [DUE-2013069](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2013069) - Collaborative Research: Broadening Participation in Computing through Authentic, Collaborative Engagement with Computing for the Greater Good.
 * [Zulip](https://zulip.com) provides sponsored hosting for [FarmData2 community discussions](https://farmdata2.zulipchat.com/#narrow/stream/270883-general).
 
 ---


### PR DESCRIPTION
Change the text "DUE-2013069" into a link in the README.md file

Make the text "DUE-2013069"  into a link using Markdown. The text is found in the  Acknowledgments section at the bottom of the README.md file

Fixes[#28](https://github.com/dickinson-comp190/GitKit-FarmData2/issues/28)
---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
