### PR TITLE
AUTHORS.md file removed from attribution section of LICENSE.md.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,34 +1,25 @@
-## FarmData2 Licensing Information ##
+FarmData2 Licensing Information
 
-FarmData2 is a [Free Cultural Work].  This document outlines the licenses that apply to FarmData2 and the agreement which governs contributions.  Complete copies of these documents can be be found in the [licenses directory]. All copies and forks of FarmData2 must be maintained in compliance with those licenses.
+FarmData2 is a Free Cultural Work. This document outlines the licenses that apply to FarmData2 and the agreement which governs contributions. Complete copies of these documents can be be found in the licenses directory. All copies and forks of FarmData2 must be maintained in compliance with those licenses.
 
-[Free Cultural Work]: https://freedomdefined.org/Definition
-[licenses directory]: licenses
-
-#### Intellectual Property ####
+Intellectual Property
 
 Contributors retain the copyright to their intellectual property.
 
-#### Contributions ####
+Contributions
 
-All contributions to FarmData2 will be licensed as a [Free Cultural Work] using the applicable license agreements as described below. Thus, before any contribution will be accepted __the contributor must certify that they have the right to license the contributed intellectual property__ under the applicable license agreement. This is done explicitly when when a contributor completes the [Developer Certificate of Origin] when opening a Pull Request, or implicitly when posting content to any public forums of the project (for example, but not limited to, issue trackers, message boards or discussion areas).
+All contributions to FarmData2 will be licensed as a Free Cultural Work using the applicable license agreements as described below. Thus, before any contribution will be accepted the contributor must certify that they have the right to license the contributed intellectual property under the applicable license agreement. This is done explicitly when when a contributor completes the Developer Certificate of Origin when opening a Pull Request, or implicitly when posting content to any public forums of the project (for example, but not limited to, issue trackers, message boards or discussion areas).
 
-[Developer Certificate of Origin]: https://developercertificate.org/
+Code License
 
-#### Code License ####
+All code in the FarmData2 project is licensed under the GNU General Public License v3 (GPL-3.0).
 
-All code in the FarmData2 project is licensed under the GNU General Public License v3 ([GPL-3.0]).
+Content License
 
-[GPL-3.0]: https://www.gnu.org/licenses/gpl-3.0.md
+All other content, including code snippets posted in public forums, is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC-BY-SA-4.0).
 
-#### Content License ####
+Attribution
 
-All other content, including code snippets posted in public forums, is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License ([CC-BY-SA-4.0]).
-
-[CC-BY-SA-4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-
-#### Attribution ####
-
-Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system.  The [AUTHORS.md](AUTHORS.md) file contains a list of all contributors to the repository and is updated periodically.
+Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system. 
 
 Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made based.


### PR DESCRIPTION
__Pull Request Description__

the AUTHORS.md file did not exist in the attribution section of LICENSE.md and so I removed the line regarding AUTHORS.md from LICENSE.md. Closes #25 .



---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
